### PR TITLE
Remove coupled BASE_URL and Ingress host

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -64,7 +64,9 @@ spec:
                   name: planka-postgresql-svcbind-custom-user
                   key: uri
             - name: BASE_URL
-              {{- if .Values.ingress.enabled }}
+              {{- if .Values.baseUrl }}
+              value: {{ .Values.baseUrl }}
+              {{- else if .Values.ingress.enabled }}
               value: {{ printf "https://%s" (first .Values.ingress.hosts).host }}
               {{- else }}
               value: http://localhost:3000

--- a/values.yaml
+++ b/values.yaml
@@ -32,8 +32,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext: {}
@@ -51,8 +50,7 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -108,6 +106,6 @@ persistence:
   enabled: false
   # existingClaim: netbox-data
   # storageClass: "-"
-
+  
   accessMode: ReadWriteOnce
   size: 10Gi

--- a/values.yaml
+++ b/values.yaml
@@ -36,8 +36,7 @@ podSecurityContext:
   {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -67,8 +66,7 @@ ingress:
   #    hosts:
   #      - planka.local
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,10 @@ fullnameOverride: ""
 # Generate a secret using openssl rand -base64 45
 secretkey: ""
 
+# Base url for Planka. Will override `ingress.hosts[0].host`
+# Defaults to `http://localhost:3000` if ingress is disabled.
+baseUrl: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -28,10 +32,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -46,10 +52,12 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
+    # Used to set planka BASE_URL if no `baseurl` is provided.
     - host: planka.local
       paths:
         - path: /
@@ -59,7 +67,8 @@ ingress:
   #    hosts:
   #      - planka.local
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -101,6 +110,6 @@ persistence:
   enabled: false
   # existingClaim: netbox-data
   # storageClass: "-"
-  
+
   accessMode: ReadWriteOnce
   size: 10Gi


### PR DESCRIPTION
Sets an overall baseUrl value to remove the need for an ingress to set a custom host. 

Tested with baseUrl set and unset and behaving as desired. I don't have then environment to triple-check if the ingress method still works but it should 

Note: 

Don't mind if I didn't do something quite right. First time contributing to open source and using Github. Work uses Gitlab :) 

Let me know if you have any questions! 

